### PR TITLE
Fix invite members

### DIFF
--- a/src/controllers/group.controller.ts
+++ b/src/controllers/group.controller.ts
@@ -174,7 +174,7 @@ export const inviteMembersToExistingGroup = async (
   req: Request,
   res: Response
 ) => {
-  const users = req.body;
+  const users = req.body?.users;
   const groupId = req.params?.groupId;
   const userId = req.query.userId as string;
 

--- a/src/tests/group.controller.test.ts
+++ b/src/tests/group.controller.test.ts
@@ -237,7 +237,7 @@ describe('testing group actions', () => {
       .request(server)
       .patch(`/groups/${groupId}/invite-members`)
       .query({ userId: userIdMain })
-      .send([userIdFriend3])
+      .send({ users: [userIdFriend3] })
       .then(res => {
         expect(res).to.have.status(200);
         done();
@@ -249,7 +249,7 @@ describe('testing group actions', () => {
       .request(server)
       .patch(`/groups/${groupId}/invite-members`)
       .query({ userId: userIdMain })
-      .send([userIdFriend6])
+      .send({ users: [userIdFriend6] })
       .then(res => {
         expect(res).to.have.status(200);
         done();
@@ -660,7 +660,7 @@ describe('testing group deletion after less than 2 members', () => {
       .request(server)
       .patch(`/groups/${groupId}/invite-members`)
       .query({ userId: userIdMain })
-      .send([userIdFriend3])
+      .send({ users: [userIdFriend3] })
       .then(res => {
         expect(res).to.have.status(200);
         done();
@@ -672,7 +672,7 @@ describe('testing group deletion after less than 2 members', () => {
       .request(server)
       .patch(`/groups/${groupId}/invite-members`)
       .query({ userId: userIdMain })
-      .send([userIdFriend6])
+      .send({ users: [userIdFriend6] })
       .then(res => {
         expect(res).to.have.status(200);
         done();


### PR DESCRIPTION
Previously our `/groups/:groupId/invite-members` endpoint extracts `users` via: 
```ts
const users = req.body;
```
and then treats it as an array: 
```ts
// add users to the group's invitedMembers array
const targetGroup = await Group.findByIdAndUpdate(groupId, {
  $push: { invitedMembers: users },
});
```

The issue is `req.body` is inherently a JSON object. We won't be able to send a HTTP request to this endpoint and have `users` be parsed as an array in the backend. 

Refactored so that we extract `users` from a field in `req.body`, which can be an array. 