### PR TITLE
remove unnecessary line

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,3 @@ httpServer.listen(process.env.SERVER_PORT, () => {
     );
   }
 });
-
-// Export the server instance to allow use elsewhere
-export default locationService;


### PR DESCRIPTION
We don't import `locationService` anywhere in our backend, so we can remove this line. 

This was probably added by me long time ago but not removed (my bad). 