### PR TITLE
Fix queue deployment

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -8,6 +8,9 @@ REDIS_PORT=6379
 # Redis Host (must be redis if communicating with redis within a docker network)
 REDIS_HOST=redis
 
+# Redis password (only used in deployment) 
+REDIS_PASSWORD=
+
 # Cloudinary cloud name
 CLOUDINARY_CLOUD_NAME=
 # Cloudinary API key

--- a/src/queue/setup/queue.setup.ts
+++ b/src/queue/setup/queue.setup.ts
@@ -13,6 +13,7 @@ const queueOptions = {
   connection: new Redis({
     host: redisHost,
     port: parseInt(process.env.REDIS_PORT || '6379'),
+    password: process.env.REDIS_PASSWORD,
   }),
 };
 

--- a/src/queue/setup/workers.setup.ts
+++ b/src/queue/setup/workers.setup.ts
@@ -16,6 +16,7 @@ const workerOptions: WorkerOptions = {
   connection: {
     host: redisHost,
     port: parseInt(process.env.REDIS_PORT || '6379'),
+    password: process.env.REDIS_PASSWORD,
   },
 };
 


### PR DESCRIPTION
## Problem

Previously, we had two Azure Container Apps (ACA): 
1. nightlight-backend -- pulled from Azure Container Registry (ACR) 
2. Redis -- pulled from Docker Registry

For reasons I am unable to pinpoint given my lack of understanding of Azure, it seemed like if we wanted to have a Redis container, we should not be using ACA. 

## Solution

Instead of using ACA for Redis, we switch to using [Azure Cache for Redis](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/). 

1. Create an Azure Cache for Redis: 

<p align="center">
<img width="450" alt="Screen Shot 2023-04-19 at 3 42 45 PM" src="https://user-images.githubusercontent.com/58854510/233195366-139ae718-b8c9-4150-b4ac-a21792d1633f.png">
</p>

2. Wait for it to deploy. Then we can get our `REDIS_HOST` and `REDIS_PORT=6379` from the main page: 

<p align="center">
<img width="450" alt="Screen Shot 2023-04-19 at 3 43 29 PM" src="https://user-images.githubusercontent.com/58854510/233195520-a6ab4ed7-0b39-42b7-934c-c3d4eb278dbd.png">
</p>

3. Configure the above to enable `Non-SSL port (6379)` under the `Ports` section

4. Go to Settings > Access Keys to get our `REDIS_PASSWORD` 

<p align="center">
<img width="300" alt="Screen Shot 2023-04-19 at 3 44 46 PM" src="https://user-images.githubusercontent.com/58854510/233195810-1c9f2e31-40e4-4749-8eb8-1b769677d3c1.png">
</p>

5. Finally, we update the REDIS_HOST, REDIS_PORT, REDIS_PASSWORD in our deployed `nightlight-backend` env variables on Azure Container App